### PR TITLE
feat: add no-duplicate-labels lint rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ The core infrastructure for GTLint is now in place:
   - `no-undefined-vars` - detects use of undefined variables
   - `no-unused-vars` - warns about defined but unused variables
   - `no-invalid-goto` - checks `*goto:` references valid `*label:` targets
+  - `no-duplicate-labels` - detects duplicate `*label:` definitions
   - `no-unreachable-code` - detects unreachable code (constant false conditions, code after `*goto:`)
   - `valid-keyword` - validates keyword names against known set
   - `valid-sub-keyword` - validates sub-keyword names

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ export default {
     'no-undefined-vars': 'error',
     'no-unused-vars': 'warn',
     'no-invalid-goto': 'error',
+    'no-duplicate-labels': 'error',
     'valid-keyword': 'error',
     'valid-sub-keyword': 'error',
     'no-unclosed-string': 'error',
@@ -139,6 +140,7 @@ GTLint includes the following linting rules:
 - **`no-undefined-vars`** - Detects use of undefined variables
 - **`no-unused-vars`** - Warns about variables that are defined but never used
 - **`no-invalid-goto`** - Ensures `*goto:` statements reference valid `*label:` targets
+- **`no-duplicate-labels`** - Detects duplicate `*label:` definitions within a program
 
 ### Syntax Validation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gt-lint",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A linter and formatter for the GuidedTrack language",
   "type": "module",
   "main": "dist/index.js",

--- a/src/linter/rules/index.ts
+++ b/src/linter/rules/index.ts
@@ -15,6 +15,7 @@ import { noInlineArgument } from './no-inline-argument.js';
 import { gotoNeedsResetInEvents } from './goto-needs-reset-in-events.js';
 import { purchaseSubkeywordConstraints } from './purchase-subkeyword-constraints.js';
 import { correctIndentation } from './correct-indentation.js';
+import { noDuplicateLabels } from './no-duplicate-labels.js';
 
 export const rules: Record<string, LintRule> = {
   'no-undefined-vars': noUndefinedVars,
@@ -33,6 +34,7 @@ export const rules: Record<string, LintRule> = {
   'goto-needs-reset-in-events': gotoNeedsResetInEvents,
   'purchase-subkeyword-constraints': purchaseSubkeywordConstraints,
   'correct-indentation': correctIndentation,
+  'no-duplicate-labels': noDuplicateLabels,
 };
 
 export function getRule(name: string): LintRule | undefined {

--- a/src/linter/rules/no-duplicate-labels.ts
+++ b/src/linter/rules/no-duplicate-labels.ts
@@ -1,0 +1,81 @@
+import type { LintRule, RuleContext } from '../linter.js';
+import type { Program, KeywordStatement, Statement } from '../../parser/ast.js';
+
+export const noDuplicateLabels: LintRule = {
+  name: 'no-duplicate-labels',
+  description: 'Disallow duplicate *label definitions',
+  severity: 'error',
+
+  create(context: RuleContext) {
+    const labelDefinitions: Array<{ name: string; line: number; column: number }> = [];
+
+    function collectLabels(node: Program | Statement): void {
+      if (!node || typeof node !== 'object') return;
+
+      if (node.type === 'Program') {
+        for (const stmt of node.body) {
+          collectLabels(stmt);
+        }
+      } else if (node.type === 'KeywordStatement') {
+        const kw = node as KeywordStatement;
+
+        if (kw.keyword === 'label' && kw.argument) {
+          let labelName = '';
+          if (kw.argument.type === 'TextContent') {
+            const text = kw.argument.parts.find(p => typeof p === 'string') as string | undefined;
+            if (text) {
+              labelName = text.trim();
+            }
+          } else if (kw.argument.type === 'Identifier') {
+            labelName = kw.argument.name;
+          }
+          if (labelName) {
+            labelDefinitions.push({
+              name: labelName,
+              line: kw.loc.start.line,
+              column: kw.loc.start.column,
+            });
+          }
+        }
+
+        // Recurse into body
+        for (const stmt of kw.body) {
+          collectLabels(stmt);
+        }
+
+        // Recurse into sub-keywords
+        for (const sub of kw.subKeywords) {
+          for (const stmt of sub.body) {
+            collectLabels(stmt);
+          }
+        }
+      } else if (node.type === 'AnswerOption') {
+        for (const stmt of node.body) {
+          collectLabels(stmt);
+        }
+      }
+    }
+
+    return {
+      Program(node: Program) {
+        collectLabels(node);
+
+        // Group labels by name and report duplicates
+        const seen = new Map<string, { line: number; column: number }>();
+
+        for (const label of labelDefinitions) {
+          const first = seen.get(label.name);
+          if (first) {
+            context.report({
+              message: `Duplicate label '${label.name}' (first defined on line ${first.line})`,
+              line: label.line,
+              column: label.column,
+            });
+          } else {
+            seen.set(label.name, { line: label.line, column: label.column });
+          }
+        }
+      },
+    };
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export const DEFAULT_LINTER_CONFIG: LinterConfig = {
     'goto-needs-reset-in-events': 'warn',
     'purchase-subkeyword-constraints': 'error',
     'correct-indentation': 'error',
+    'no-duplicate-labels': 'error',
   },
   format: DEFAULT_FORMATTER_CONFIG,
   ignore: ['**/node_modules/**', '**/dist/**'],

--- a/tests/linter.test.ts
+++ b/tests/linter.test.ts
@@ -189,6 +189,61 @@ describe('Linter', () => {
     });
   });
 
+  describe('no-duplicate-labels rule', () => {
+    it('should report error for duplicate label definitions', () => {
+      const source = `*label: myLabel
+*goto: myLabel
+*label: myLabel`;
+      const result = lint(source);
+
+      const dupErrors = result.messages.filter(m => m.ruleId === 'no-duplicate-labels');
+      expect(dupErrors).toHaveLength(1);
+      expect(dupErrors[0].severity).toBe('error');
+      expect(dupErrors[0].message).toContain("Duplicate label 'myLabel'");
+      expect(dupErrors[0].message).toContain('line 1');
+    });
+
+    it('should not report error when all labels are unique', () => {
+      const source = `*label: labelA
+*label: labelB
+*label: labelC`;
+      const result = lint(source);
+
+      const dupErrors = result.messages.filter(m => m.ruleId === 'no-duplicate-labels');
+      expect(dupErrors).toHaveLength(0);
+    });
+
+    it('should report multiple errors for three identical labels', () => {
+      const source = `*label: dup
+*label: dup
+*label: dup`;
+      const result = lint(source);
+
+      const dupErrors = result.messages.filter(m => m.ruleId === 'no-duplicate-labels');
+      expect(dupErrors).toHaveLength(2);
+    });
+
+    it('should detect duplicates inside nested blocks', () => {
+      const source = `*label: top
+*if: 1
+\t*label: top`;
+      const result = lint(source);
+
+      const dupErrors = result.messages.filter(m => m.ruleId === 'no-duplicate-labels');
+      expect(dupErrors).toHaveLength(1);
+      expect(dupErrors[0].message).toContain("Duplicate label 'top'");
+    });
+
+    it('should be configurable to off', () => {
+      const source = `*label: x
+*label: x`;
+      const result = lint(source, { rules: { 'no-duplicate-labels': 'off' } });
+
+      const dupErrors = result.messages.filter(m => m.ruleId === 'no-duplicate-labels');
+      expect(dupErrors).toHaveLength(0);
+    });
+  });
+
   describe('indent-style rule', () => {
     it('should report error for space indentation', () => {
       const source = `*if: true

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "gtlint-vscode",
   "displayName": "GTLint - GuidedTrack Linter",
   "description": "Linting, formatting, and code actions for GuidedTrack (.gt) files",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "gtlint",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Adds a new `no-duplicate-labels` lint rule that detects duplicate `*label:` definitions within a GuidedTrack program.

Closes #7

Generated with [Claude Code](https://claude.ai/code)