### PR TITLE
feat: add HTML syntax highlighting for *html blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ The core infrastructure for GTLint is now in place:
   - Bold text formatting (`*text*`) rendered in bold
   - Italic text formatting (`/text/`) rendered in italics
   - Context-aware: formatting disabled for URL/path keywords
+  - Embedded HTML syntax highlighting in `*html` blocks (delegates to VSCode's built-in HTML grammar)
 - Integration with the linter (shows diagnostics in editor)
 - Language configuration (brackets, comments, auto-closing pairs)
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ GTLint provides a VSCode extension for an integrated development experience:
    - Bold text (`*text*`) renders in bold
    - Italic text (`/text/`) renders in italics
    - Context-aware: formatting disabled in URL/path keywords
+   - `*html` blocks get full HTML syntax highlighting, IntelliSense, and auto-closing tags via VSCode's built-in HTML support
 3. Linting diagnostics appear automatically in the editor
 4. Errors and warnings are underlined in your code
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gt-lint",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A linter and formatter for the GuidedTrack language",
   "type": "module",
   "main": "dist/index.js",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "gtlint-vscode",
   "displayName": "GTLint - GuidedTrack Linter",
   "description": "Linting, formatting, and code actions for GuidedTrack (.gt) files",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "gtlint",
   "engines": {
     "vscode": "^1.85.0"
@@ -45,7 +45,10 @@
       {
         "language": "guidedtrack",
         "scopeName": "source.guidedtrack",
-        "path": "./syntaxes/guidedtrack.tmLanguage.json"
+        "path": "./syntaxes/guidedtrack.tmLanguage.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.html": "html"
+        }
       }
     ],
     "configuration": {

--- a/vscode-extension/syntaxes/guidedtrack.tmLanguage.json
+++ b/vscode-extension/syntaxes/guidedtrack.tmLanguage.json
@@ -5,6 +5,7 @@
   "patterns": [
     { "include": "#comments" },
     { "include": "#expression-keywords" },
+    { "include": "#html-block" },
     { "include": "#keywords-no-formatting" },
     { "include": "#keywords" },
     { "include": "#sub-keywords-no-formatting" },
@@ -42,6 +43,18 @@
             }
           }
         }
+      ]
+    },
+    "html-block": {
+      "begin": "^(\\t*)(\\*)(html)\\s*$",
+      "end": "^(?!$)(?!\\1\\t)",
+      "beginCaptures": {
+        "2": { "name": "punctuation.definition.keyword.guidedtrack" },
+        "3": { "name": "keyword.control.guidedtrack" }
+      },
+      "contentName": "meta.embedded.block.html",
+      "patterns": [
+        { "include": "text.html.basic" }
       ]
     },
     "keywords-no-formatting": {


### PR DESCRIPTION
Add embedded HTML language support to the VSCode extension so that content inside `*html` blocks gets full HTML syntax highlighting, IntelliSense, and auto-closing tags via VSCode's built-in HTML grammar.

Closes #8

Generated with [Claude Code](https://claude.ai/code)